### PR TITLE
Fix dashboard showing 'Email sent' for skipped newsletters

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -299,7 +299,13 @@
         if (data.lastPost) {
           document.getElementById('post-title').textContent = data.lastPost.title || '-';
           document.getElementById('post-date').textContent = formatDate(data.lastPost.publishedAt);
-          document.getElementById('email-sent-date').textContent = formatDate(data.lastPost.emailSentAt);
+
+          // Check if email was actually sent
+          if (data.lastPost.emailSentAt) {
+            document.getElementById('email-sent-date').textContent = formatDate(data.lastPost.emailSentAt);
+          } else {
+            document.getElementById('email-sent-date').textContent = 'Not sent (missing send_newsletter tag)';
+          }
         }
         
         // Update subscribers table

--- a/src/subscriberManager.js
+++ b/src/subscriberManager.js
@@ -293,22 +293,24 @@ function getLastPost() {
 }
 
 // Update the last post information
-function updateLastPost(post) {
+function updateLastPost(post, emailWasSent = false) {
   try {
     const data = JSON.parse(fs.readFileSync(SUBSCRIBERS_FILE, 'utf8'));
-    
+
     data.lastPost = {
       id: post.id,
       title: post.title,
       publishedAt: post.pubDate,
-      emailSentAt: new Date().toISOString()
+      emailSentAt: emailWasSent ? new Date().toISOString() : null
     };
-    
-    data.stats.totalEmailsSent += data.subscribers.length;
+
+    if (emailWasSent) {
+      data.stats.totalEmailsSent += data.subscribers.length;
+    }
     data.stats.lastRunAt = new Date().toISOString();
-    
+
     fs.writeFileSync(SUBSCRIBERS_FILE, JSON.stringify(data, null, 2));
-    logger.info(`Updated last post: ${post.title}`);
+    logger.info(`Updated last post: ${post.title}${emailWasSent ? ' (email sent)' : ' (email skipped)'}`);
     return true;
   } catch (error) {
     logger.error(`Failed to update last post: ${error.message}`);


### PR DESCRIPTION
Fixes #2

The dashboard was incorrectly showing "Email sent" even when emails were not sent due to missing "send_newsletter" tag. This commit fixes the issue by:

1. Modified subscriberManager.updateLastPost() to accept emailWasSent parameter, only setting emailSentAt and incrementing counters when emails are actually sent

2. Updated index.js to track whether emails were sent and pass the flag to updateLastPost()

3. Updated dashboard to display "Not sent (missing send_newsletter tag)" when emailSentAt is null

Now the dashboard accurately reflects the newsletter delivery status based on tag presence.